### PR TITLE
Decrement thread count by 1

### DIFF
--- a/src/lib/counter.rs
+++ b/src/lib/counter.rs
@@ -22,7 +22,7 @@ impl Counter {
         }
 
         for entry in fs::read_dir(path)?.filter(|d| {
-            for exclude in &["target", ".git"] {
+            for exclude in ["target", ".git"] {
                 let path = d.as_ref().unwrap().path();
 
                 if path.ends_with(exclude) {

--- a/src/lib/threads.rs
+++ b/src/lib/threads.rs
@@ -4,14 +4,18 @@ use std::{fs, thread};
 
 pub fn handle_in_thread(tx: mpsc::Sender<usize>, files: Vec<PathBuf>) -> thread::JoinHandle<()> {
     thread::spawn(move || {
-        let mut result = 0;
-
-        for file in files {
-            if let Ok(s) = fs::read_to_string(file) {
-                result += s.split('\n').count();
-            };
-        }
-
-        tx.send(result).unwrap();
+        tx.send(handle(files)).unwrap();
     })
+}
+
+pub fn handle(files: Vec<PathBuf>) -> usize {
+    let mut result = 0;
+
+    for file in files {
+        if let Ok(s) = fs::read_to_string(file) {
+            result += s.split('\n').count();
+        }
+    }
+
+    result
 }


### PR DESCRIPTION
 - When a user passes no njobs to the command or app, and/or passes 1 job prevent any threads from spawning and just use the main thread.
 - When a user does specify more than 1 njobs, decrease that number by 1 to reserve that for the main thread.

Closes #2